### PR TITLE
fix artifact upload

### DIFF
--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -22,7 +22,3 @@ jobs:
         id: draft_release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: echo
-        run: echo $UPLOAD_URL
-        env:
-          UPLOAD_URL: ${{ steps.draft_release.outputs.upload_url }}

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -13,12 +13,14 @@ on:
   push:
     branches:
       - master
+    tags-ignore:
+      - *
 
 jobs:
   update_draft_release:
     runs-on: ubuntu-latest
     steps:
-      - uses: toolmantim/release-drafter@v5.2.0
+      - uses: toolmantim/release-drafter@v5.5.0
         id: draft_release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -22,3 +22,7 @@ jobs:
         id: draft_release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: echo
+        run: echo $UPLOAD_URL
+        env:
+          UPLOAD_URL: ${{ steps.draft_release.outputs.upload_url }}

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -13,8 +13,6 @@ on:
   push:
     branches:
       - master
-    tags-ignore:
-      - *
 
 jobs:
   update_draft_release:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/setup-go@v1
         with:
           go-version: '1.13.5'
-      - uses: toolmantim/release-drafter@v5.2.0
+      - uses: toolmantim/release-drafter@v5.5.0
         id: draft_release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,6 @@ jobs:
         id: draft_release
         run: |
           echo -n ::set-output name=upload_url::
-          curl -sH "Authorization: token $GITHUB_TOKEN" https://api.github.com/repos/$GITHUB_REPOSITORY/releases
           curl -sH "Authorization: token $GITHUB_TOKEN" https://api.github.com/repos/$GITHUB_REPOSITORY/releases | jq -rc '.[] | select(.draft) | .upload_url'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,12 +8,15 @@
 name: Release
 
 #on: create
-on: push
+on:
+  push:
+    branches:
+      - master
 
 jobs:
   upload:
     runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/')
+#    if: startsWith(github.ref, 'refs/tags/')
     steps:
       - uses: actions/checkout@v1
       - uses: actions/setup-go@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,8 @@
 #
 name: Release
 
-on: create
+#on: create
+on: push
 
 jobs:
   upload:
@@ -21,7 +22,7 @@ jobs:
       - name: Get Draft Release
         id: draft_release
         run: |
-          echo -n ::set-output name=upload_url::
+          echo -n set-output name=upload_url::
           echo curl -sH "Authorization: token $GITHUB_TOKEN" https://api.github.com/repos/$GITHUB_REPOSITORY/releases | jq -rc '.[] | select(.draft) | .upload_url'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,8 +25,9 @@ jobs:
       - name: Get Draft Release
         id: draft_release
         run: |
-          echo -n set-output name=upload_url::
-          echo curl -sH "Authorization: token $GITHUB_TOKEN" https://api.github.com/repos/$GITHUB_REPOSITORY/releases | jq -rc '.[] | select(.draft) | .upload_url'
+          echo -n ::set-output name=upload_url::
+          curl -sH "Authorization: token $GITHUB_TOKEN" https://api.github.com/repos/$GITHUB_REPOSITORY/releases
+          curl -sH "Authorization: token $GITHUB_TOKEN" https://api.github.com/repos/$GITHUB_REPOSITORY/releases | jq -rc '.[] | select(.draft) | .upload_url'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: echo

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,10 @@ jobs:
         id: draft_release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: echo
+        run: echo $UPLOAD_URL
+        env:
+          UPLOAD_URL: ${{ steps.draft_release.outputs.upload_url }}
       - name: Build
         run: go build ./cmd/docker-volume-proxy
       - name: Test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,8 +18,11 @@ jobs:
       - uses: actions/setup-go@v1
         with:
           go-version: '1.13.5'
-      - uses: toolmantim/release-drafter@v5.5.0
+      - name: Get Draft Release
         id: draft_release
+        run: |
+          echo -n ::set-output name=upload_url::
+          echo curl -sH "Authorization: token $GITHUB_TOKEN" https://api.github.com/repos/$GITHUB_REPOSITORY/releases | jq -rc '.[] | select(.draft) | .upload_url'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: echo

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,16 +7,12 @@
 #
 name: Release
 
-#on: create
-on:
-  push:
-    branches:
-      - master
+on: create
 
 jobs:
   upload:
     runs-on: ubuntu-latest
-#    if: startsWith(github.ref, 'refs/tags/')
+    if: startsWith(github.ref, 'refs/tags/')
     steps:
       - uses: actions/checkout@v1
       - uses: actions/setup-go@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,10 +25,6 @@ jobs:
           curl -sH "Authorization: token $GITHUB_TOKEN" https://api.github.com/repos/$GITHUB_REPOSITORY/releases | jq -rc '.[] | select(.draft) | .upload_url'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: echo
-        run: echo $UPLOAD_URL
-        env:
-          UPLOAD_URL: ${{ steps.draft_release.outputs.upload_url }}
       - name: Build
         run: go build ./cmd/docker-volume-proxy
       - name: Test


### PR DESCRIPTION
## Proposed Changes

The upload process for `docker-volume-proxy` was not working properly. I had assumed that release-drafter would set `upload_url` regardless, but it only does so if it actually updates a release (and only on `v5.4.0` or later). This switches to just directly calling the github API to fetch the first (and presumably only) draft release and use that as the upload URL.

## Testing

Pushed tags to personal repo, verified assets uploaded correctly to draft release.